### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         curseddelta={}:main
     '''.format(MODULE_NAME),
     python_requires='>=3.5',
-    install_requires=['deltachat', 'urwid'],
+    install_requires=['deltachat', 'urwid', 'urwid_readline'],
     include_package_data=True,
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
         curseddelta={}:main
     '''.format(MODULE_NAME),
     python_requires='>=3.5',
-    install_requires=['deltachat', 'urwid', 'urwid_readline'],
+    dependency_links=['https://m.devpi.net/dc/master'],
+    install_requires=['deltachat>=0.800.1.dev238', 'urwid', 'urwid_readline'],
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
* Adds `urwid_readline` as dependency,
* updates `deltachat` dependency to make curseddelta runnable after `setup.py install` (previously this would install deltachat-0.800.0, which results in `ImportError: cannot import name 'account_hookimpl' from 'deltachat'`)

I don't like to pin the deltachat dependency on this specific version, but I did not find out how to specify a more generic "use the newest thing" (`deltachat>=0.800.1` doesn't work). 